### PR TITLE
Use named constant for NodeType check

### DIFF
--- a/content.js
+++ b/content.js
@@ -6,7 +6,7 @@ for (var i = 0; i < elements.length; i++) {
     for (var j = 0; j < element.childNodes.length; j++) {
         var node = element.childNodes[j];
 
-        if (node.nodeType === 3) {
+        if (node.nodeType === Node.TEXT_NODE) {
             var text = node.nodeValue;
             var replacedText = text.replace(/Mormon/gi, '[VICTORY FOR 😈]');
 


### PR DESCRIPTION
Use the named constant `Node.TEXT_NODE` instead of the magic number `3` in the main logic.

The goal of this PR is to improve code readability; I had to Google what 3 meant, but the rest of the code seems fairly easy to follow.